### PR TITLE
Fix critical nil bug after verifying the receipt data

### DIFF
--- a/SoomlaiOSStore/SoomlaStore.m
+++ b/SoomlaiOSStore/SoomlaStore.m
@@ -211,8 +211,8 @@ static NSString* developerPayload = NULL;
                                                                @"transactionIdentifier": transaction.transactionIdentifier,
                                                                @"receiptBase64": receiptString,
                                                                @"transactionDate": transaction.transactionDate,
-                                                               @"originalTransactionDate": transaction.originalTransaction.transactionDate,
-                                                               @"originalTransactionIdentifier": transaction.originalTransaction.transactionIdentifier
+                                                               @"originalTransactionDate": transaction.originalTransaction ? transaction.originalTransaction.transactionDate : transaction.transactionDate,
+                                                               @"originalTransactionIdentifier": transaction.originalTransaction ? transaction.originalTransaction.transactionIdentifier : transaction.transactionIdentifier
                                                                }
                                 andPayload:developerPayload];
     [pvi giveAmount:1];


### PR DESCRIPTION
This is very critical bug as the app will always crash when open it