### PR TITLE
Fix nil bug of SoomlaVerification when refreshing the receipt data

### DIFF
--- a/SoomlaiOSStore/SoomlaStore.m
+++ b/SoomlaiOSStore/SoomlaStore.m
@@ -262,8 +262,7 @@ static NSString* developerPayload = NULL;
         PurchasableVirtualItem* pvi = [[StoreInfo getInstance] purchasableItemWithProductId:transaction.payment.productIdentifier];
 
         if (VERIFY_PURCHASES) {
-//            SoomlaVerification *sv = [[SoomlaVerification alloc] initWithTransaction:transaction andPurchasable:pvi];
-            SoomlaVerification *sv = [[SoomlaVerification getInstance] initWithTransaction:transaction andPurchasable:pvi];
+            SoomlaVerification *sv = [[SoomlaVerification alloc] initWithTransaction:transaction andPurchasable:pvi];
             
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(purchaseVerified:) name:EVENT_MARKET_PURCHASE_VERIF object:sv];
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(unexpectedVerificationError:) name:EVENT_UNEXPECTED_ERROR_IN_STORE object:sv];

--- a/SoomlaiOSStore/SoomlaVerification.h
+++ b/SoomlaiOSStore/SoomlaVerification.h
@@ -20,14 +20,13 @@
 @class PurchasableVirtualItem;
 
 @interface SoomlaVerification : NSObject <NSURLConnectionDelegate, SKRequestDelegate>{
-    NSMutableData *responseData;
+    __strong NSMutableData *responseData;
     int responseCode;
-    PurchasableVirtualItem *purchasable;
-    SKPaymentTransaction* transaction;
+    __strong PurchasableVirtualItem *purchasable;
+    __strong SKPaymentTransaction* transaction;
 }
 
 - (id) initWithTransaction:(SKPaymentTransaction*)t andPurchasable:(PurchasableVirtualItem*)pvi;
 
 - (void)verifyData;
-+ (SoomlaVerification*)getInstance;
 @end

--- a/SoomlaiOSStore/SoomlaVerification.h
+++ b/SoomlaiOSStore/SoomlaVerification.h
@@ -29,5 +29,5 @@
 - (id) initWithTransaction:(SKPaymentTransaction*)t andPurchasable:(PurchasableVirtualItem*)pvi;
 
 - (void)verifyData;
-
++ (SoomlaVerification*)getInstance;
 @end

--- a/SoomlaiOSStore/SoomlaVerification.h
+++ b/SoomlaiOSStore/SoomlaVerification.h
@@ -20,7 +20,7 @@
 @class PurchasableVirtualItem;
 
 @interface SoomlaVerification : NSObject <NSURLConnectionDelegate, SKRequestDelegate>{
-    __strong NSMutableData *responseData;
+    NSMutableData *responseData;
     int responseCode;
     __strong PurchasableVirtualItem *purchasable;
     __strong SKPaymentTransaction* transaction;

--- a/SoomlaiOSStore/SoomlaVerification.m
+++ b/SoomlaiOSStore/SoomlaVerification.m
@@ -98,6 +98,11 @@ static SoomlaVerification* _instance = nil;
         [request setHTTPMethod:@"POST"];
         [request setValue:postLength forHTTPHeaderField:@"Content-Length"];
         [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+        
+        if( SERVER_AUTHORIZATION_TOKEN && ![SERVER_AUTHORIZATION_TOKEN isEqualToString:@""]  ) {
+            [request setValue:SERVER_AUTHORIZATION_TOKEN forHTTPHeaderField:@"Authorization"];
+        }
+        
         [request setHTTPBody:postData];
         
         NSURLConnection *conn = [[NSURLConnection alloc] initWithRequest:request delegate:self];
@@ -163,7 +168,17 @@ static SoomlaVerification* _instance = nil;
         NSString* errorMsg = @"";
         if (responseDict) {
             @try {
-                errorMsg = [responseDict objectForKey:@"error"];
+                id errorObject = [responseDict objectForKey:@"error"];
+                if([errorObject isKindOfClass:[NSDictionary class]]) {
+                    errorMsg = [errorObject objectForKey:@"message"];
+                }
+                else if([errorObject isKindOfClass:[NSString class]]){
+                    errorMsg = (NSString *) errorObject;
+                }
+                else {
+                    errorMsg = @"Unknown Error";
+                }
+
             } @catch (NSException* e) {
                 LogError(TAG, @"There was a problem when verifying when handling response.");
             }

--- a/SoomlaiOSStore/SoomlaVerification.m
+++ b/SoomlaiOSStore/SoomlaVerification.m
@@ -29,13 +29,28 @@
 @implementation SoomlaVerification
 
 static NSString* TAG = @"SOOMLA SoomlaVerification";
+static SoomlaVerification* _instance = nil;
+
+
++ (SoomlaVerification*)getInstance{
+
+    
+    @synchronized( self ) {
+        if( _instance == nil ) {
+            _instance = [[SoomlaVerification alloc] init];
+        }
+    }
+    
+    return _instance;
+}
 
 - (id) initWithTransaction:(SKPaymentTransaction*)t andPurchasable:(PurchasableVirtualItem*)pvi {
-    if (self = [super init]) {
-        transaction = t;
-        purchasable = pvi;
-        tryAgain = YES;
-    }
+    if(_instance == nil)
+      self = [SoomlaVerification getInstance];
+
+    transaction = t;
+    purchasable = pvi;
+    tryAgain = YES;
     
     return self;
 }
@@ -138,7 +153,7 @@ static NSString* TAG = @"SOOMLA SoomlaVerification";
                 SKReceiptRefreshRequest *req = [[SKReceiptRefreshRequest alloc] initWithReceiptProperties:nil];
                 req.delegate = self;
                 [req start];
-                
+
                 // we return here ...
                 return;
             }

--- a/SoomlaiOSStore/SoomlaVerification.m
+++ b/SoomlaiOSStore/SoomlaVerification.m
@@ -61,7 +61,6 @@ static NSMutableArray* cacheRetryRequestReceipt;
     }
     
     if (data) {
-        
         NSMutableDictionary* postDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                   [data base64Encoding], @"receipt_base64",
                                   transaction.payment.productIdentifier, @"productId",
@@ -121,6 +120,8 @@ static NSMutableArray* cacheRetryRequestReceipt;
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection {
     NSString* dataStr = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
     NSNumber* verifiedNum = nil;
+    NSNumber* successNum = nil;
+    
     if ([dataStr isEqualToString:@""]) {
         LogError(TAG, @"There was a problem when verifying. Got an empty response. Will try again later.");
         [StoreEventHandling postUnexpectedError:ERR_VERIFICATION_FAIL forObject:self];
@@ -131,12 +132,13 @@ static NSMutableArray* cacheRetryRequestReceipt;
     @try {
         responseDict = [SoomlaUtils jsonStringToDict:dataStr];
         verifiedNum = (NSNumber*)[responseDict objectForKey:@"verified"];
+        successNum = (NSNumber*)[responseDict objectForKey:@"success"];
     } @catch (NSException* e) {
         LogError(TAG, @"There was a problem when verifying when handling response.");
     }
     
     BOOL verified = NO;
-    if (responseCode==200 && verifiedNum) {
+    if (responseCode==200 && successNum && [successNum boolValue] && verifiedNum) {
         
         verified = [verifiedNum boolValue];
         if (!verified) {

--- a/SoomlaiOSStore/SoomlaVerification.m
+++ b/SoomlaiOSStore/SoomlaVerification.m
@@ -138,7 +138,7 @@ static NSMutableArray* cacheRetryRequestReceipt;
     }
     
     BOOL verified = NO;
-    if (responseCode==200 && successNum && [successNum boolValue] && verifiedNum) {
+    if (responseCode==200 && verifiedNum) {
         
         verified = [verifiedNum boolValue];
         if (!verified) {

--- a/SoomlaiOSStore/StoreConfig.h
+++ b/SoomlaiOSStore/StoreConfig.h
@@ -36,3 +36,4 @@ extern const int METADATA_VERSION;
 extern BOOL VERIFY_PURCHASES;
 
 extern NSString* VERIFY_URL;
+extern NSString* SERVER_AUTHORIZATION_TOKEN;

--- a/SoomlaiOSStore/StoreConfig.m
+++ b/SoomlaiOSStore/StoreConfig.m
@@ -22,4 +22,4 @@ BOOL VERIFY_PURCHASES = NO;
 
 NSString* VERIFY_URL = @"https://verify.soom.la/verify_ios";
 
-
+NSString* SERVER_AUTHORIZATION_TOKEN;


### PR DESCRIPTION
- Fix nill bug when calling this [[SKPaymentQueue defaultQueue] finishTransaction: transaction];

- NSJSonSerialization can not parse NSDate and NSURL, so I convert them into NSString :

<code>
   NSString *transactionDate = transaction.transactionDate ? [NSDateFormatter localizedStringFromDate:transaction.transactionDate
                                                                                             dateStyle:NSDateFormatterShortStyle
                                                                                             timeStyle:NSDateFormatterFullStyle] : @"";

    NSString *transactionDateOriginal = transaction.originalTransaction ? [NSDateFormatter localizedStringFromDate:[transaction.originalTransaction transactionDate]
                                                                                                         dateStyle:NSDateFormatterShortStyle
                                                                                                         timeStyle:NSDateFormatterFullStyle] : transactionDate;


- SKReceiptRefreshRequest *req = [[SKReceiptRefreshRequest alloc] initWithReceiptProperties:nil];
                req.delegate = self;
                [req start];
</code>

When callback of SKReceiptRefreshRequest get called, instance of SoomlaVerification has been destroyed. So I make SoomlaVerification singleton so that it's always exist ready to process the callbacks of SKReceiptRefreshRequest.