### PR TITLE
Add Verification Started Event to signal when the verification has begun

### DIFF
--- a/SoomlaiOSStore/SoomlaStore.m
+++ b/SoomlaiOSStore/SoomlaStore.m
@@ -300,6 +300,8 @@ static NSString* developerPayload = NULL;
         PurchasableVirtualItem* pvi = [[StoreInfo getInstance] purchasableItemWithProductId:transaction.payment.productIdentifier];
 
         if (VERIFY_PURCHASES) {
+            [StoreEventHandling postVerificationStarted:pvi];
+
             SoomlaVerification *sv = [[SoomlaVerification alloc] initWithTransaction:transaction andPurchasable:pvi];
                    
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(purchaseVerified:) name:EVENT_MARKET_PURCHASE_VERIF object:sv];

--- a/SoomlaiOSStore/StoreEventHandling.h
+++ b/SoomlaiOSStore/StoreEventHandling.h
@@ -46,6 +46,7 @@
 #define EVENT_MARKET_ITEMS_REFRESH_FINISHED @"MarketItemsRefreshFinished"
 #define EVENT_MARKET_ITEMS_REFRESH_FAILED   @"MarketItemsRefreshFailed"
 #define EVENT_UNEXPECTED_STORE_ERROR        @"UnexpectedStoreError"
+#define EVENT_VERIFICATION_STARTED          @"VerificationStarted"
 
 
 // UserInfo Elements
@@ -127,6 +128,8 @@
 + (void)postRestoreTransactionsStarted;
 
 + (void)postUnexpectedError:(int)code forObject:(id)object;
+
++ (void)postVerificationStarted:(PurchasableVirtualItem*)purchasableVirtualItem;
 
 + (void)postSoomlaStoreInitialized;
 

--- a/SoomlaiOSStore/StoreEventHandling.m
+++ b/SoomlaiOSStore/StoreEventHandling.m
@@ -44,6 +44,7 @@ extern BOOL VERIFY_PURCHASES;
     [[NSNotificationCenter defaultCenter] addObserver:observer selector:selector name:EVENT_MARKET_ITEMS_REFRESH_STARTED object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:observer selector:selector name:EVENT_MARKET_ITEMS_REFRESH_FINISHED object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:observer selector:selector name:EVENT_MARKET_ITEMS_REFRESH_FAILED object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:observer selector:selector name:EVENT_VERIFICATION_STARTED object:nil];
 }
 
 + (void)postBillingSupported{
@@ -167,6 +168,11 @@ extern BOOL VERIFY_PURCHASES;
             DICT_ELEMENT_ERROR_CODE : @(code)
     };
     [[NSNotificationCenter defaultCenter] postNotificationName:EVENT_UNEXPECTED_STORE_ERROR object:object userInfo:userInfo];
+}
+
++ (void)postVerificationStarted:(PurchasableVirtualItem*)purchasableVirtualItem {
+    NSDictionary *userInfo = @{ DICT_ELEMENT_PURCHASABLE: purchasableVirtualItem };
+    [[NSNotificationCenter defaultCenter] postNotificationName:EVENT_VERIFICATION_STARTED object:self userInfo:userInfo];
 }
 
 + (void) postSoomlaStoreInitialized {


### PR DESCRIPTION
This is the ios side of the Verification Started event.

The Unity side is PR: https://github.com/soomla/unity3d-store/pull/491